### PR TITLE
textland: flush input buffer after waiting on events

### DIFF
--- a/textland/display.py
+++ b/textland/display.py
@@ -244,9 +244,9 @@ class CursesDisplay(AbstractDisplay):
         return Size(x, y)
 
     def wait_for_event(self) -> Event:
+        key_code = self._screen.getch()
         # throw away all typeaheads
         self._curses.flushinp()
-        key_code = self._screen.getch()
         # XXX -1 is for OSX
         if key_code == self._curses.KEY_RESIZE or key_code == -1:
             return Event(EVENT_RESIZE, self.get_display_size())


### PR DESCRIPTION
This small change does actually give better results on snappy like devices.
And it seems to be the common way to use it (see http://nullege.com/codes/search/curses.flushinp)
